### PR TITLE
list common layer for multiple images

### DIFF
--- a/account/Dockerfile
+++ b/account/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN  DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q python3-tornado && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY    *.py /home/
 CMD     ["/bin/bash","-c","/home/main.py"]

--- a/ad-content/frontend/Dockerfile
+++ b/ad-content/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka;
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY    *.py /home/
 COPY    inventory.json /home/

--- a/ad-decision/Dockerfile
+++ b/ad-decision/Dockerfile
@@ -1,8 +1,7 @@
 
 FROM ubuntu:18.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-kazoo python3-requests; \
-    rm -rf /var/lib/apt/lists/*;
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY   *.py /home/
 COPY   *.conf /etc/nginx/

--- a/ad-insertion/ad-transcode/Dockerfile
+++ b/ad-insertion/ad-transcode/Dockerfile
@@ -1,8 +1,7 @@
 
 FROM xeon-ubuntu1804-ffmpeg
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends python3-kafka python3-kazoo python3-requests; \
-    rm -rf /var/lib/apt/lists/*;
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY   *.py /home/
 CMD    ["/bin/bash","-c","/home/main.py"]

--- a/ad-insertion/analytic-db/Dockerfile
+++ b/ad-insertion/analytic-db/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM ubuntu:18.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q python3-kafka python3-kazoo python3-requests && rm -rf /var/lib/apt/lists/*;
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY   *.py /home/
 CMD    ["/bin/bash","-c","/home/main.py"]

--- a/ad-insertion/frontend/Dockerfile
+++ b/ad-insertion/frontend/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM ubuntu:18.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q nginx python3-tornado python3-kafka python3-kazoo && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY   *.py /home/
 COPY   *.conf /etc/nginx/

--- a/cdn/Dockerfile
+++ b/cdn/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests;
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY    *.conf /etc/nginx/
 COPY    *.py /home/

--- a/content-provider/frontend/Dockerfile
+++ b/content-provider/frontend/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM ubuntu:18.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q nginx python3-tornado python3-kafka && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY   *.py /home/
 COPY   *.conf /etc/nginx/

--- a/content-provider/transcode/Dockerfile
+++ b/content-provider/transcode/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM xeon-ubuntu1804-ffmpeg
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q python3-kafka python3-kazoo python3-psutil && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y -q --no-install-recommends nginx python3-tornado python3-kafka python3-urllib3 python3-requests python3-psutil python3-kazoo && rm -rf /var/lib/apt/lists/*;
 
 COPY   *.py /home/
 CMD    ["/bin/bash","-c","/home/workload.py tx&/home/main.py"]


### PR DESCRIPTION
Many images have slightly different build tools required.. slight difference in dockerfile line make it a different recipe, so docker will have to build from scratch.. making many images having common build-tools layer would allow images to use caching at the cost of increase in docker image size.
Time improvement difference- WIP.