### PR TITLE
fix to allow build as root

### DIFF
--- a/account/Dockerfile
+++ b/account/Dockerfile
@@ -7,11 +7,13 @@ WORKDIR /home
 EXPOSE  80
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/ad-content/ad-decision/Dockerfile
+++ b/ad-content/ad-decision/Dockerfile
@@ -5,17 +5,17 @@ COPY   *.py /home/
 COPY   *.conf /etc/nginx/
 CMD    ["/bin/bash","-c","/home/main.py&/usr/sbin/nginx"]
 WORKDIR /home
-EXPOSE 8080
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home; \
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
      touch /var/run/nginx.pid && \
      mkdir -p /var/log/nginx /var/lib/nginx /var/www/cache && \
-     chown -R ${USER}.${GROUP} /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
-USER ${USER}
+     chown -R ${UID}:${GID} /home /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
+USER ${UID}
 ####

--- a/ad-content/archive/Dockerfile
+++ b/ad-content/archive/Dockerfile
@@ -3,12 +3,14 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y -q youtube-dl && rm -rf /var/lib/apt/lists/*
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####
 

--- a/ad-content/frontend/Dockerfile
+++ b/ad-content/frontend/Dockerfile
@@ -9,15 +9,16 @@ WORKDIR /home
 EXPOSE  8080
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home; \
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
      touch /var/run/nginx.pid && \
      mkdir -p /var/log/nginx /var/lib/nginx /var/www/cache && \
-     chown -R ${USER}.${GROUP} /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
-USER ${USER}
+     chown -R ${UID}:${GID} /home /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
+USER ${UID}
 ####
 

--- a/ad-insertion/ad-segment/Dockerfile
+++ b/ad-insertion/ad-segment/Dockerfile
@@ -3,12 +3,14 @@ FROM openvisualcloud/xeon-ubuntu1804-media-ffmpeg:20.4
 RUN apt-get update && apt-get install -y -q bc && rm -rf /var/lib/apt/lists/*;
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####
 

--- a/ad-insertion/ad-static/Dockerfile
+++ b/ad-insertion/ad-static/Dockerfile
@@ -2,12 +2,14 @@
 FROM openvisualcloud/xeon-ubuntu1804-media-ffmpeg:20.4
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####
 

--- a/ad-insertion/ad-transcode/Dockerfile
+++ b/ad-insertion/ad-transcode/Dockerfile
@@ -10,15 +10,16 @@ CMD    ["/bin/bash","-c","/home/main.py"]
 WORKDIR /home
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home; \
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
      touch /var/run/nginx.pid && \
      mkdir -p /var/log/nginx /var/lib/nginx /var/www/cache && \
-     chown -R ${USER}.${GROUP} /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
-USER ${USER}
+     chown -R ${UID}:${GID} /home /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
+USER ${UID}
 ####
 

--- a/ad-insertion/analytics/VCAC-A/ffmpeg/Dockerfile
+++ b/ad-insertion/analytics/VCAC-A/ffmpeg/Dockerfile
@@ -25,11 +25,13 @@ WORKDIR /home
 CMD ["/home/analyze.py"]
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home;
-#USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home/${USER} -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/ad-insertion/analytics/VCAC-A/gst/Dockerfile
+++ b/ad-insertion/analytics/VCAC-A/gst/Dockerfile
@@ -34,12 +34,13 @@ WORKDIR /home
 CMD ["/home/analyze.py"]
 
 ###
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home;
-#USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####
-#

--- a/ad-insertion/analytics/Xeon/ffmpeg/Dockerfile
+++ b/ad-insertion/analytics/Xeon/ffmpeg/Dockerfile
@@ -25,11 +25,13 @@ WORKDIR /home
 CMD ["/home/analyze.py"]
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home;
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/ad-insertion/analytics/Xeon/gst/Dockerfile
+++ b/ad-insertion/analytics/Xeon/gst/Dockerfile
@@ -36,11 +36,13 @@ WORKDIR /home
 CMD ["/home/analyze.py"]
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home;
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/ad-insertion/frontend/Dockerfile
+++ b/ad-insertion/frontend/Dockerfile
@@ -8,15 +8,16 @@ WORKDIR /home
 EXPOSE 8080
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home; \
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
      touch /var/run/nginx.pid && \
      mkdir -p /var/log/nginx /var/lib/nginx /var/www/cache /var/www/adstatic /var/www/adinsert && \
-     chown -R ${USER}.${GROUP} /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
-USER ${USER}
+     chown -R ${UID}:${GID} /home /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
+USER ${UID}
 ####
 

--- a/ad-insertion/kafka2db/Dockerfile
+++ b/ad-insertion/kafka2db/Dockerfile
@@ -5,12 +5,14 @@ COPY   *.py /home/
 CMD    ["/bin/bash","-c","/home/main.py"]
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####
 

--- a/cdn/Dockerfile
+++ b/cdn/Dockerfile
@@ -7,15 +7,16 @@ CMD     ["/bin/bash","-c","/home/main.py&/usr/sbin/nginx"]
 EXPOSE  8080
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home; \
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
      touch /var/run/nginx.pid && \
      mkdir -p /var/log/nginx /var/lib/nginx /var/www/cache && \
-     chown -R ${USER}.${GROUP} /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
+     chown -R ${UID}:${GID} /home /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
 USER ${USER}
 ####
 

--- a/content-provider/archive/Dockerfile
+++ b/content-provider/archive/Dockerfile
@@ -3,11 +3,13 @@ FROM openvisualcloud/xeon-ubuntu1804-media-ffmpeg:20.4
 RUN apt-get update && apt-get install -y -q youtube-dl bc wget && rm -rf /var/lib/apt/lists/*;
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/content-provider/frontend/Dockerfile
+++ b/content-provider/frontend/Dockerfile
@@ -6,17 +6,17 @@ COPY   *.conf /etc/nginx/
 COPY   html /var/www/html
 CMD    ["/bin/bash","-c","/home/main.py&/usr/sbin/nginx"]
 VOLUME ["/var/www/archive","/var/www/dash","/var/www/hls"]
-EXPOSE 8080
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home; \
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
      touch /var/run/nginx.pid && \
      mkdir -p /var/log/nginx /var/lib/nginx /var/www/cache /var/www/video && \
-     chown -R ${USER}.${GROUP} /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
-USER ${USER}
+     chown -R ${UID}:${GID} /home /var/run/nginx.pid /var/www /var/log/nginx /var/lib/nginx
+USER ${UID}
 ####

--- a/content-provider/transcode/Dockerfile
+++ b/content-provider/transcode/Dockerfile
@@ -9,11 +9,13 @@ COPY   *.py /home/
 CMD    ["/bin/bash","-c","/home/workload.py tx-&/home/main.py"]
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/deployment/certificate/Dockerfile
+++ b/deployment/certificate/Dockerfile
@@ -3,11 +3,13 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y openssh-server
 
 ####
-ARG  USER
-ARG  GROUP
+ARG  USER=docker
+ARG  GROUP=docker
 ARG  UID
 ARG  GID
 ## must use ; here to ignore user exist status code
-RUN  groupadd -f -g ${GID} ${GROUP};useradd -d /home -g ${GROUP} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER};chown -R ${USER}.${GROUP} /home
-USER ${USER}
+RUN  [ ${GID} -gt 0 ] && groupadd -f -g ${GID} ${GROUP}; \
+     [ ${UID} -gt 0 ] && useradd -d /home -g ${GID} -K UID_MAX=${UID} -K UID_MIN=${UID} ${USER}; \
+     chown -R ${UID}:${GID} /home
+USER ${UID}
 ####

--- a/script/build.sh
+++ b/script/build.sh
@@ -8,8 +8,6 @@ fi
 PLATFORM="${1:-Xeon}"
 FRAMEWORK="${2:-gst}"
 REGISTRY="$7"
-USER="docker"
-GROUP="docker"
 
 build_docker() {
     docker_file="$1"
@@ -19,7 +17,7 @@ build_docker() {
     if test -f "$docker_file.m4"; then
         m4 -I "$(dirname $docker_file)" "$docker_file.m4" > "$docker_file"
     fi
-    (cd "$DIR"; docker build --network host --file="$docker_file" "$@" -t "$image_name" "$DIR" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/--build-arg /') --build-arg USER=${USER} --build-arg GROUP=${GROUP} --build-arg UID=$(id -u) --build-arg GID=$(id -g))
+    (cd "$DIR"; docker build --network host --file="$docker_file" "$@" -t "$image_name" "$DIR" $(env | cut -f1 -d= | grep -E '_(proxy|REPO|VER)$' | sed 's/^/--build-arg /') --build-arg UID=$(id -u) --build-arg GID=$(id -g))
 
     # if REGISTRY is specified, push image to the private registry
     if [ -n "$REGISTRY" ]; then


### PR DESCRIPTION
Please double check runtime error on master:

set /ad-insertion-segment/hls/car-detection.mp4/adstream/guest/1/link to /adstatic
zk_path: /ad-transcode/hls/people-detection.mp4/adstream/guest/0/360p.m3u8
query db with time range: 6.0-16.0
Checking pre-transcoded stream: /var/www/adsegment/hls/catfood.mp4
Transcoding the AD segment http://ad-content-service:8080/catfood.mp4

Traceback (most recent call last):
  File "/home/process.py", line 168, in ADTranscode
    cmd = GetABRCommand(stream, msg.target_path, msg.streaming_type, msg.GetRedition(), duration=msg.segment_duration, fade_type="audio", content_type="ad")
  File "/home/abr_hls_dash.py", line 63, in GetABRCommand
    for item in clip_info["streams"]:
KeyError: 'streams'

